### PR TITLE
Fix: Release Workflow and API Check

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,6 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: ./gradlew build
 
-      - name: KotlinPoet check
+      - name: API check
         if: "matrix.os != 'ubuntu-latest'"
         run: ./gradlew check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,6 @@
 name: Publish release to Maven Central
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,14 +2,14 @@ Releasing
 =========
 
 1. Change the version in `gradle.properties` to a non-SNAPSHOT version.
-2. Update `docs/changelog.md` for the impending release.
-3. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
-4. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version).
-5. Update `gradle.properties` to the next SNAPSHOT version.
-6. `git commit -am "Prepare next development version."`.
-7. `git push && git push --tags`.
+2. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
+3. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version).
+4. Update `gradle.properties` to the next SNAPSHOT version.
+5. `git commit -am "Prepare next development version."`.
+6. `git push && git push --tags`.
 
 This will trigger a GitHub Action workflow which will create a GitHub release and upload the
 release artifacts to [Maven Central][maven-central].
 
-[maven-central]: https://repo.maven.apache.org/maven2/com/squareup/kotlinpoet/
+[maven-central]: https://repo.maven.apache.org/maven2/org/openMF/fineract-client-cmp/
+```

--- a/fineract-client/build.gradle.kts
+++ b/fineract-client/build.gradle.kts
@@ -14,10 +14,10 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kover)
     alias(libs.plugins.dokka)
-    alias(libs.plugins.maven)
     id("kotlinx-serialization")
     alias(libs.plugins.ksp)
     alias(libs.plugins.ktorfit)
+    alias(libs.plugins.maven)
 }
 
 kotlin {
@@ -65,6 +65,10 @@ dependencies {
     add("kspIosX64", libs.ktorfit.ksp)
     add("kspIosArm64", libs.ktorfit.ksp)
     add("kspIosSimulatorArm64", libs.ktorfit.ksp)
+}
+
+tasks.named("sourcesJar").configure {
+    dependsOn(tasks.named("kspCommonMainKotlinMetadata"))
 }
 
 // Maven publishing configuration


### PR DESCRIPTION
Removed release trigger from release workflow and made it manual. Updated KotlinPoet check to API check in build workflow.

Updated the sourcesJar task to depend on kspCommonMainKotlinMetadata. Updated RELEASING.md to reflect the changes in the release process.